### PR TITLE
Update pyproject.toml to make dependencies independent from build tool

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -11,5 +11,5 @@ runs:
       run: pip install poetry
       shell: bash
     - name: Install Dependencies in Virtual Environment
-      run: poetry install
+      run: poetry lock; poetry install
       shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,34 @@
-[tool.poetry]
+[project]
 name = "rapidhrv"
-version = "0.2.7"
+version = "0.2.8"
 description = "A package for preprocessing, analyzing and visualizing cardiac data"
 authors = [
-  "Peter Kirk <p.kirk@ucl.ac.uk>",
-  "Alexander Davidson Bryan <alxdb@pm.me>",
+  { name = "Peter Kirk", email = "p.kirk@ucl.ac.uk"   },
+  { name = "Alexander Davidson Bryan",email = "alxdb@pm.me" },
 ]
 license = "MIT"
 readme = "README.md"
+
+dependencies = [
+	     "numpy>=2.3.2",
+	     "scipy>=1.16.1",
+	     "scikit-learn>=1.7.1",
+	     "pandas>=2.3.2",	
+	     "h5py>=3.3.0",
+	     "dash>=3.2.0"
+]
+
+requires-python = ">= 3.11"
+
+[project.optional-dependencies]
+gui = []
+cli = [
+    "jupyter>=1.0.0",
+    "matplotlib>=3.4.2"
+]
+
+[tool.setuptools]
+packages = [ "rapidhrv", "resources", "tests"]
 
 [tool.poe.tasks]
 format = [{ cmd = "black ." }, { cmd = "isort ." }]
@@ -26,17 +47,6 @@ ignore_missing_imports = true
 [tool.black]
 line-length = 99
 
-[tool.poetry.dependencies]
-python = ">=3.11,<3.13"
-numpy = "^2.3.2"
-scipy = "^1.16.1"
-scikit-learn = "^1.7.1"
-pandas = "^2.3.2"
-jupyter = { version = "^1.0.0", optional = true }
-matplotlib = { version = "^3.4.2", optional = true }
-h5py = "^3.3.0"
-dash = "^3.2.0"
-
 [tool.poetry.group.dev.dependencies]
 black = "^25.1.0"
 isort = "^6.0.1"
@@ -50,6 +60,3 @@ pytest-cov = "^6.2.1"
 [tool.poetry.extras]
 notebooks = ["jupyter", "matplotlib"]
 
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
I updated the toml file to what is requested by setup tools,
it is now possible to put the dependencies in a tool independent way.
